### PR TITLE
Handle session conflicts when room reassignment fails

### DIFF
--- a/ConsoleApp1/AIExamHelper.cs
+++ b/ConsoleApp1/AIExamHelper.cs
@@ -1251,6 +1251,24 @@ namespace DTcms.Core.Common.Helpers
                         return null;
                     }
 
+                    var fallbackSubjectIds = groups
+                        .SelectMany(g => g.Subjects)
+                        .Select(s => s.Subject.ModelSubjectId)
+                        .Distinct()
+                        .Where(id =>
+                            candidateSessionMap.TryGetValue(id, out var options)
+                                && options.Any(opt => opt.Session.SessionKey != session.SessionKey))
+                        .ToList();
+
+                    if (fallbackSubjectIds.Count > 0)
+                    {
+                        retryRequest = new SessionReassignmentRequest(
+                            session,
+                            fallbackSubjectIds,
+                            lastFailure ?? $"场次[{session.TimeNo}]无法完成考场安排。");
+                        return null;
+                    }
+
                     error.AppendLine(lastFailure ?? $"场次[{session.TimeNo}]无法完成考场安排。");
                     return null;
                 }

--- a/ConsoleApp1/AIExamHelper.cs
+++ b/ConsoleApp1/AIExamHelper.cs
@@ -1131,6 +1131,13 @@ namespace DTcms.Core.Common.Helpers
 
                             if (!needRetry)
                             {
+                                if (!requiresSessionChange
+                                    && conflictingClasses != null
+                                    && conflictingClasses.Count > 0)
+                                {
+                                    requiresSessionChange = true;
+                                }
+
                                 if (requiresSessionChange)
                                 {
                                     if (sessionRetry == null)

--- a/ConsoleApp1/AIExamHelper.cs
+++ b/ConsoleApp1/AIExamHelper.cs
@@ -3137,13 +3137,13 @@ namespace DTcms.Core.Common.Helpers
                 if (avoidRooms != null && avoidRooms.Count > 0)
                 {
                     var filtered = availableRooms.Where(r => !avoidRooms.Contains(r.RoomId)).ToList();
-                    if (filtered.Count > 0 && TryBuildGradePlansForRooms(grade, gradeClasses, filtered, out gradePlans, out failure))
+                    if (filtered.Count > 0 && TryBuildGradePlansForRooms(grade, gradeClasses, filtered, avoidRooms, out gradePlans, out failure))
                     {
                         return true;
                     }
                 }
 
-                return TryBuildGradePlansForRooms(grade, gradeClasses, availableRooms, out gradePlans, out failure);
+                return TryBuildGradePlansForRooms(grade, gradeClasses, availableRooms, avoidRooms, out gradePlans, out failure);
             }
 
             private List<RoomSnapshot> GetAvailableRoomsForGrade(int grade)
@@ -3178,7 +3178,7 @@ namespace DTcms.Core.Common.Helpers
             }
 
 
-            private bool TryBuildGradePlansForRooms(int grade, List<AIExamModelClass> gradeClasses, List<RoomSnapshot> rooms, out Dictionary<int, List<ClassRoomSlice>> gradePlans, out string? failure)
+            private bool TryBuildGradePlansForRooms(int grade, List<AIExamModelClass> gradeClasses, List<RoomSnapshot> rooms, HashSet<int>? avoidRooms, out Dictionary<int, List<ClassRoomSlice>> gradePlans, out string? failure)
             {
                 gradePlans = new Dictionary<int, List<ClassRoomSlice>>();
                 failure = null;

--- a/ConsoleApp1/AIExamHelper.cs
+++ b/ConsoleApp1/AIExamHelper.cs
@@ -475,9 +475,7 @@ namespace DTcms.Core.Common.Helpers
             {
                 var room = best.Rooms[i];
                 var assigned = best.Distribution[i];
-                var capacity = _roomLookup.TryGetValue(room.RoomId, out var info)
-                    ? info.SeatCount
-                    : room.Capacity;
+                var capacity = room.Capacity;
                 allocation.Add(new ClassRoomSlice(room.RoomId, assigned, capacity));
                 usedRooms.Add(room.RoomId);
                 selectedRoomIds.Add(room.RoomId);


### PR DESCRIPTION
## Summary
- treat irrecoverable room clashes as session-level conflicts
- request session rescheduling when conflicting classes cannot be reassigned

## Testing
- not run (environment lacks dotnet SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e4bc70cccc832b9e7b029aa8ac0cb2