### PR TITLE
Allow unlimited room candidates per class

### DIFF
--- a/ConsoleApp1/AIExamHelper.cs
+++ b/ConsoleApp1/AIExamHelper.cs
@@ -14,7 +14,8 @@ namespace DTcms.Core.Common.Helpers
     /// </summary>
     public static class AIExamHelper
     {
-        private const int MaxRoomCandidatesPerClass = 15;
+        // 0 表示不限制候选考场数量，避免由于过早裁剪导致大班级无法满足同楼层多考场的需求。
+        private const int MaxRoomCandidatesPerClass = 0;
 
         /// <summary>
         /// 自动排考
@@ -807,7 +808,7 @@ namespace DTcms.Core.Common.Helpers
                             return null;
                         }
 
-                        if (candidateIndices.Count > MaxRoomCandidatesPerClass)
+                        if (MaxRoomCandidatesPerClass > 0 && candidateIndices.Count > MaxRoomCandidatesPerClass)
                         {
                             var originalCandidates = candidateIndices.ToList();
                             var preferredSet = new HashSet<int>();

--- a/ConsoleApp1/AIExamHelper.cs
+++ b/ConsoleApp1/AIExamHelper.cs
@@ -1385,6 +1385,16 @@ namespace DTcms.Core.Common.Helpers
 
                         if (roomEvent == null)
                         {
+                            var usageLimit = GetRoomUsageLimit(slot.TimeNo);
+                            if (usageLimit > 0 && roomEvents.Count >= usageLimit)
+                            {
+                                error.AppendLine($"考场 {allocation.Room.Room.ModelRoomName ?? allocation.Room.RoomId.ToString()} 在 {slot.Date} {slot.TimeNo} 的考试次数已达到上限 {usageLimit} 次，无法继续安排科目 {request.Subject.Subject.ModelSubjectName ?? subjectId.ToString()}。");
+                                return null;
+                            }
+                        }
+
+                        if (roomEvent == null)
+                        {
                             foreach (var existingGlobalEvent in container.RoomEvents.Where(e => e.Room.RoomId == allocation.Room.RoomId))
                             {
                                 if (existingGlobalEvent.Slot.Index == slot.Index && existingGlobalEvent.Subject.SubjectId == subjectId)
@@ -3227,6 +3237,26 @@ namespace DTcms.Core.Common.Helpers
         private static bool IsTimeOverlap(DateTime startA, DateTime endA, DateTime startB, DateTime endB)
         {
             return startA < endB && startB < endA;
+        }
+
+        private static int GetRoomUsageLimit(string? timeNo)
+        {
+            if (string.IsNullOrWhiteSpace(timeNo))
+            {
+                return 0;
+            }
+
+            switch (timeNo.Trim())
+            {
+                case "上午场":
+                    return 2;
+                case "下午场":
+                    return 3;
+                case "晚上场":
+                    return 1;
+                default:
+                    return 0;
+            }
         }
 
         #endregion

--- a/ConsoleApp1/AIExamHelper.cs
+++ b/ConsoleApp1/AIExamHelper.cs
@@ -1281,7 +1281,20 @@ namespace DTcms.Core.Common.Helpers
                     var fallbackOffsets = ComputeSubjectStartOffsets(slotSubjects, slot, allocationResult, config, model);
                     if (fallbackOffsets == null)
                     {
-                        error.AppendLine($"无法在场次 {slot.Date} {slot.Start:HH:mm} 为科目的考试安排合适的开始时间。");
+                        error.AppendLine($"无法在场次 {slot.Date} {slot.Start:HH:mm} 为科目的考试安排非重叠的开始时间，请尝试调整到其他场次。");
+
+                        var impactedSubjects = slotSubjects
+                            .Select(s => s.SubjectId)
+                            .Distinct()
+                            .ToList();
+
+                        conflict = new SlotTimeConflict
+                        {
+                            TimeIndex = timeIndex,
+                            SubjectIds = impactedSubjects,
+                            ClassIds = CollectClassIdsForSubjects(allocationResult, impactedSubjects.ToArray())
+                        };
+
                         return null;
                     }
 


### PR DESCRIPTION
## Summary
- allow classes to consider all compatible rooms when building room assignments
- prevent premature candidate trimming from blocking large classes that require multiple adjacent rooms

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e731975c24832b94c978e585517c96